### PR TITLE
Fix UI offset bug in termui mode

### DIFF
--- a/termui.go
+++ b/termui.go
@@ -213,7 +213,7 @@ func tuiListUpdate(infoMap lib.ProcInfoMap, list lib.Pidlist, procSum lib.ProcSa
 		graphColors[strPid] = colorList[colorPos]
 
 		mainList.Items[i+1] = fmt.Sprintf("[%26s %6d](fg-color%d) %7s %7s %7s %7s %7s %7s %7s %5s %5s %7s %5s %4d %4d %4d",
-			trunc(infoMap[pid].Friendly, 28),
+			trunc(infoMap[pid].Friendly, 26),
 			pid,
 			colorPos,
 			trim(scale(float64(procHist[pid].Ustime.Min())), 7),


### PR DESCRIPTION
Process column was not being rendered correctly: 
![screenshot_2016-07-29_12_20_48](https://cloud.githubusercontent.com/assets/40828/17260811/60e0e79e-5587-11e6-939f-15536eb45be9.png)
